### PR TITLE
Add Allow-Credentials Header to GET responses

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -53,6 +53,11 @@ module.exports = function(SPlugin, serverlessPath) {
         }
 
         response.responseParameters['method.response.header.Access-Control-Allow-Origin'] = '\'' + policy.allowOrigin + '\'';
+
+        // Set allow-credentials header on all GET responses as these will not be preflighted
+        if (evt.endpoint.method === 'GET' && !_.isUndefined(policy.allowCredentials)) {
+          response.responseParameters['method.response.header.Access-Control-Allow-Credentials'] = '\'' + policy.allowCredentials + '\'';
+        }
       });
 
       return Promise.resolve(evt);

--- a/test/index.js
+++ b/test/index.js
@@ -119,6 +119,27 @@ describe('ServerlessCors', function() {
       })
     });
 
+    it('should add an "Access-Control-Allow-Credentials" header to GET function when "allowCredentials" is set', function(done) {
+      let plugin = new CorsPlugin(s);
+
+      plugin.addCorsHeaders({
+        endpoint: {
+          method: 'GET',
+          module: { custom: {} },
+          function: { custom: {
+            cors: { allowOrigin: 'http://function.test', allowCredentials: true }
+          }},
+          responses: {
+            default: { statusCode: '200' }
+          }
+        }
+      }).then(function(evt) {
+        let headers = evt.endpoint.responses.default.responseParameters;
+        headers['method.response.header.Access-Control-Allow-Credentials'].should.equal('\'true\'');
+        done();
+      })
+    });
+
     it('should preserve existing headers when cors is configured for function', function(done) {
       let plugin = new CorsPlugin(s);
 


### PR DESCRIPTION
Ran into a bit of an edge case w/ GET requests being made where `withCredentials` is set `true`.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#Requests_with_credentials

> Line 7 shows the flag on XMLHttpRequest that has to be set in order to make the invocation with Cookies, namely the withCredentials boolean value.  By default, the invocation is made without Cookies.  Since this is a simple GET request, it is not preflighted, but the browser will reject any response that does not have the Access-Control-Allow-Credentials: true header, and not make the response available to the invoking web content.

https://stackoverflow.com/questions/24687313/what-exactly-does-the-access-control-allow-credentials-header-do#comment48552925_24689738

Thanks for the awesome plugin!