### PR TITLE
removed no longer existing getModule (sls v 0.4.0)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -142,15 +142,11 @@ module.exports = function(SPlugin, serverlessPath) {
     }
 
     _isCorsEnabled(endpoint) {
-      return !_.isUndefined(endpoint.getFunction().getModule().custom.cors) ||
-        !_.isUndefined(endpoint.getFunction().custom.cors);
+      return !_.isUndefined(endpoint.getFunction().custom.cors);
     }
 
     _getEndpointPolicy(endpoint) {
-      let policy = _.merge({},
-        endpoint.getFunction().getModule().custom.cors,
-        endpoint.getFunction().custom.cors
-      );
+      let policy = endpoint.getFunction().custom.cors;
 
       let schema = Joi.object().keys({
         allowOrigin: Joi.string().required(),


### PR DESCRIPTION
I removed getModule because it's been removed from sls starting from 0.4.0, and as a result current version of plugin does not work with the most recent version of sls. 