### PR TITLE
Expose headers in methods other than OPTIONS

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -56,6 +56,10 @@ module.exports = function(S) {
 
         response.responseParameters['method.response.header.Access-Control-Allow-Origin'] = '\'' + policy.allowOrigin + '\'';
 
+        if (!_.isUndefined(policy.exposeHeaders)) {
+          response.responseParameters['method.response.header.Access-Control-Expose-Headers'] = '\'' + policy.exposeHeaders + '\'';
+        }
+
         // Set allow-credentials header on all GET responses as these will not be preflighted
         if (populatedEndpoint.method === 'GET' && !_.isUndefined(policy.allowCredentials)) {
           response.responseParameters['method.response.header.Access-Control-Allow-Credentials'] = '\'' + policy.allowCredentials + '\'';

--- a/test/index.js
+++ b/test/index.js
@@ -143,6 +143,24 @@ describe('ServerlessCors', function() {
       });
     });
 
+    it('should add an "Access-Control-Expose-Headers" header to function when "exposeHeaders" is set', function(done) {
+      const func = _bootstrapEndpoint('someFunction', 'GET'),
+        endpoint = s.getProject().getEndpoint('someFunction~GET');
+      const nonStandardHeader = 'Content-length'
+      func.custom.cors = {
+        allowOrigin: 'http://function.test',
+        exposeHeaders: [nonStandardHeader]
+      };
+
+      plugin.addCorsHeaders({
+        options: { name: 'someFunction~GET', stage: 'dev', region: 'eu-west-1' }
+      }).then(function(evt) {
+        const headers = endpoint.responses.default.responseParameters;
+        headers['method.response.header.Access-Control-Expose-Headers'].should.contain(nonStandardHeader);
+        done();
+      });
+    });
+
     it('should preserve existing headers when cors is configured for function', function(done) {
       const func = _bootstrapEndpoint('someFunction', 'GET'),
         endpoint = s.getProject().getEndpoint('someFunction~GET');

--- a/test/index.js
+++ b/test/index.js
@@ -146,17 +146,17 @@ describe('ServerlessCors', function() {
     it('should add an "Access-Control-Expose-Headers" header to function when "exposeHeaders" is set', function(done) {
       const func = _bootstrapEndpoint('someFunction', 'GET'),
         endpoint = s.getProject().getEndpoint('someFunction~GET');
-      const nonStandardHeader = 'Content-length'
+      const nonStandardExposedHeader = 'Content-length';
       func.custom.cors = {
         allowOrigin: 'http://function.test',
-        exposeHeaders: [nonStandardHeader]
+        exposeHeaders: [nonStandardExposedHeader]
       };
 
       plugin.addCorsHeaders({
         options: { name: 'someFunction~GET', stage: 'dev', region: 'eu-west-1' }
       }).then(function(evt) {
         const headers = endpoint.responses.default.responseParameters;
-        headers['method.response.header.Access-Control-Expose-Headers'].should.contain(nonStandardHeader);
+        headers['method.response.header.Access-Control-Expose-Headers'].should.contain(nonStandardExposedHeader);
         done();
       });
     });


### PR DESCRIPTION
The value from exposeHeaders should be applied to all requests if it is set. 