### PR TITLE
Support compatibility with serverless-models-plugin

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -112,6 +112,16 @@ module.exports = function(S) {
           requestParameters: {},
           requestTemplates: {
             'application/json': '{"statusCode": 200}'
+          },
+          responses: {
+            default: {
+              statusCode: "200",
+              responseParameters: {},
+              responseModels: {},
+              responseTemplates: {
+                "application/json": ""
+              }
+            }
           }
         }, func);
 


### PR DESCRIPTION
Using this plugin in conjunction with the serverless-models-plugin (https://github.com/HyperBrain/serverless-models-plugin) causes an error

`OPTIONS - /apiEndpoint: Model not defined:`

**The Fix** 
Add default definition for endpoint "responses" config, similar to what is created by the boilerplate endpoint generator. Notice "responseModels" is set to an empty object which allows compatibility with serverless-models-plugin without requiring us to define a model.
